### PR TITLE
Update Urban Airship SDK to 8.2.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.urbanairship.android:urbanairship-sdk:[8.0,8.1)'
+    compile 'com.urbanairship.android:urbanairship-sdk:[8.2,8.3)'
     testCompile 'junit:junit:4.12'
     testCompile  files('libs/java-json.jar')
     testCompile "org.mockito:mockito-core:1.+"


### PR DESCRIPTION
Updates to the latest Urban Airship SDK with a fix to the LTV in the retail event templates.