### PR TITLE
Fix in-app message takeOff not being called before shared exception

### DIFF
--- a/src/main/java/com/mparticle/kits/MParticleAutopilot.java
+++ b/src/main/java/com/mparticle/kits/MParticleAutopilot.java
@@ -63,7 +63,8 @@ public class MParticleAutopilot extends Autopilot {
 
     @Override
     public boolean allowEarlyTakeOff(@NonNull Context context) {
-        return false;
+        AirshipConfigOptions config = createAirshipConfigOptions(context);
+        return config != null && !UAStringUtil.isEmpty(config.getAppKey()) && !UAStringUtil.isEmpty(config.getAppSecret());
     }
 
     /**


### PR DESCRIPTION
When our SDK is displaying an in-app message, the app could background and suspend the app. If the user navigates back, the activity state will be restored and our in-app message will call to `UAirship.shared()` possibly before takeOff is called due to how the kit initializes Urban Airship.

This change allows "early" takeoff to happen (when app starts) if we have a valid airship config to use. This should ensure that UA is initialized before the activity is restored.

Updated to UA SDK 9.0.x was somewhat painful so I am going to add some changes to SDK 9.1.0 to make it easier to update the kit.

Testing:
The setup instructions to build seem to have changed, so I cant event verify it builds. Could someone verify the build as well as point me to updated instructions? I will need to do more extensive changes to support UA SDK 9.1.0