### PR TITLE
fix: [GH-139] Disable Airship from prompting for notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     compileOnly 'androidx.legacy:legacy-support-v4:1.0.0'
-    api 'com.urbanairship.android:urbanairship-core:16.8.1'
+    api 'com.urbanairship.android:urbanairship-core:16.9.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation files('libs/java-json.jar')
 }

--- a/src/main/kotlin/com/mparticle/kits/MParticleAutopilot.kt
+++ b/src/main/kotlin/com/mparticle/kits/MParticleAutopilot.kt
@@ -21,6 +21,7 @@ class MParticleAutopilot : Autopilot() {
             .setNotificationIcon(preferences.getInt(NOTIFICATION_ICON_NAME, 0))
             .setNotificationAccentColor(preferences.getInt(NOTIFICATION_COLOR, 0))
             .setCustomPushProvider(MParticlePushProvider.instance)
+            .setIsPromptForPermissionOnUserNotificationsEnabled(false)
         if (MParticle.getInstance()?.environment == MParticle.Environment.Development) {
             optionsBuilder.setDevelopmentAppKey(preferences.getString(APP_KEY, null))
                 .setDevelopmentAppSecret(preferences.getString(APP_SECRET, null))


### PR DESCRIPTION
 ## Summary
Disables prompting for notifications when user notifications are enabled on the Airship instance.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 Not tested locally. I do not have an mparticle account to verify. Tested the change locally on my mparticless sample app.

To test this, run the mparticle integration with Airship on an Android 13 devices. Verify takeOff is called and user notifications are not prompted.

